### PR TITLE
Scroll to the top of the page and set focus to the first input in react

### DIFF
--- a/src/react/reactpage.tsx
+++ b/src/react/reactpage.tsx
@@ -11,6 +11,8 @@ export class SurveyPage extends React.Component<any, any> {
     private survey: SurveyModel;
     private creator: ISurveyCreator;
     protected css: any;
+    protected pageNode: any;
+
     constructor(props: any) {
         super(props);
         this.page = props.page;
@@ -24,6 +26,25 @@ export class SurveyPage extends React.Component<any, any> {
         this.creator = nextProps.creator;
         this.css = nextProps.css;
     }
+    componentDidMount() {
+        if (this.pageNode) {
+            var firstField = this.pageNode.querySelector(
+                "input:not(:disabled):not([readonly]):not([type=hidden])" +  
+                ",select:not(:disabled):not([readonly])"+
+                ",textarea:not(:disabled):not([readonly])");
+            firstField && firstField.focus();
+        }
+    }
+    componentDidUpdate() {
+        if (this.page.isVisible && this.page.isActive && this.pageNode) {
+            var firstField = this.pageNode.querySelector(
+                "input:not(:disabled):not([readonly]):not([type=hidden])" +  
+                ",select:not(:disabled):not([readonly])"+
+                ",textarea:not(:disabled):not([readonly])");
+            firstField && firstField.focus();
+            this.pageNode && this.pageNode.parentNode.scrollIntoView({ behavior: "instant", block: "start", });
+        }
+    }
     render(): JSX.Element {
         if (this.page == null || this.survey == null || this.creator == null) return null;
         var title = this.renderTitle();
@@ -33,7 +54,7 @@ export class SurveyPage extends React.Component<any, any> {
             rows.push(this.createRow(questionRows[i], i));
         }
         return (
-            <div>
+            <div ref={node => this.pageNode = node }>
                 {title}
                 {rows}
                 </div>

--- a/src/react/reactquestion.tsx
+++ b/src/react/reactquestion.tsx
@@ -29,20 +29,43 @@ export class SurveyQuestion extends React.Component<any, any> {
         this.questionBase = question;
         this.question = question instanceof Question ? question : null;
         var value = this.question ? this.question.value : null;
-        this.state = { visible: this.questionBase.visible, value: value, error: 0, renderWidth: 0 };
+        this.state = { 
+            visible: this.questionBase.visible, value: value, error: 0, renderWidth: 0,
+            visibleIndexValue: -1
+        };
+        /*
         var self = this;
         if (this.questionBase) {
             this.questionBase.renderWidthChangedCallback = function () {
                 self.state.renderWidth = self.state.renderWidth + 1;
                 self.setState(self.state);
             }
-        }
+            this.questionBase.visibleIndexChangedCallback = function() {
+                self.state.visibleIndexValue = self.questionBase.visibleIndex;
+                self.setState(self.state);
+            }
+        }*/
     }
     componentDidMount() {
-        if (this.questionBase) this.questionBase["react"] = this;
+        if (this.questionBase) {
+            var self = this;
+            this.questionBase["react"] = self;
+            this.questionBase.renderWidthChangedCallback = function () {
+                self.state.renderWidth = self.state.renderWidth + 1;
+                self.setState(self.state);
+            }
+            this.questionBase.visibleIndexChangedCallback = function() {
+                self.state.visibleIndexValue = self.questionBase.visibleIndex;
+                self.setState(self.state);
+            }
+        }
     }
     componentWillUnmount() {
-        if (this.questionBase) this.questionBase["react"] = null;
+        if (this.questionBase) {
+            this.questionBase["react"] = null;
+            this.questionBase.renderWidthChangedCallback = null;
+            this.questionBase.visibleIndexChangedCallback = null;
+        }
     }
     render(): JSX.Element {
         if (!this.questionBase || !this.creator) return null;

--- a/src/react/reactquestioncheckbox.tsx
+++ b/src/react/reactquestioncheckbox.tsx
@@ -94,7 +94,7 @@ export class SurveyQuestionCheckboxItem extends React.Component<any, any> {
         if (itemWidth) {
             divStyle["width"] = itemWidth;
         }
-        var isChecked = this.question.value && this.question.value.indexOf(this.item.value) > -1;
+        var isChecked = (this.question.value && this.question.value.indexOf(this.item.value) > -1) || false;
         var otherItem = (this.item.value === this.question.otherItem.value && isChecked) ? this.renderOther() : null;
         return this.renderCheckbox(isChecked, divStyle, otherItem);
     }


### PR DESCRIPTION
Intended to fix #133.  This patch to reactpage.tsx sets focus to the first input and scrolls to the top of the page on page transition.  It's important to note that document elements and the survey title won't be scrolled into view and that behavior might be more desirable.  I chose to scroll the element containing the page to the top rather than the page itself so that the top padding/margin is preserved.